### PR TITLE
Support className and style prop for OTPublisher and OTSubscriber

### DIFF
--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -170,7 +170,8 @@ export default class OTPublisher extends Component {
   }
 
   render() {
-    return <div ref={(node) => { this.node = node; }} />;
+    const { className, style } = this.props;
+    return <div className={className} style={style} ref={(node) => { this.node = node; }} />;
   }
 }
 
@@ -184,6 +185,8 @@ OTPublisher.propTypes = {
     publish: PropTypes.func,
     unpublish: PropTypes.func,
   }),
+  className: PropTypes.string,
+  style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   eventHandlers: PropTypes.objectOf(PropTypes.func),
   onInit: PropTypes.func,
@@ -193,6 +196,8 @@ OTPublisher.propTypes = {
 
 OTPublisher.defaultProps = {
   session: null,
+  className: '',
+  style: {},
   properties: {},
   eventHandlers: null,
   onInit: null,

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -106,7 +106,8 @@ export default class OTSubscriber extends Component {
   }
 
   render() {
-    return <div ref={(node) => { this.node = node; }} />;
+    const { className, style } = this.props;
+    return <div className={className} style={style} ref={(node) => { this.node = node; }} />;
   }
 }
 
@@ -118,6 +119,8 @@ OTSubscriber.propTypes = {
     subscribe: PropTypes.func,
     unsubscribe: PropTypes.func,
   }),
+  className: PropTypes.string,
+  style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   eventHandlers: PropTypes.objectOf(PropTypes.func),
   onSubscribe: PropTypes.func,
@@ -127,6 +130,8 @@ OTSubscriber.propTypes = {
 OTSubscriber.defaultProps = {
   stream: null,
   session: null,
+  className: '',
+  style: {},
   properties: {},
   eventHandlers: null,
   onSubscribe: null,

--- a/test/OTPublisher.spec.js
+++ b/test/OTPublisher.spec.js
@@ -38,6 +38,32 @@ describe('OTPublisher', () => {
     });
   });
 
+  describe('with className prop', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(<OTPublisher className="myclass" />);
+    });
+
+    it('should render class on wrapper element', () => {
+      const divWrapper = wrapper.render().find('div.myclass');
+      expect(divWrapper.length).toBe(1);
+    });
+  });
+
+  describe('with style prop', () => {
+    let wrapper;
+    const style = { color: 'red' };
+
+    beforeEach(() => {
+      wrapper = mount(<OTPublisher style={style} />);
+    });
+
+    it('should render style attribute on wrapper element', () => {
+      expect(wrapper.containsMatchingElement(<div style={style} />)).toEqual(true);
+    });
+  });
+
   describe('with session prop', () => {
     let session;
 

--- a/test/OTSubscriber.spec.js
+++ b/test/OTSubscriber.spec.js
@@ -21,6 +21,32 @@ describe('OTSubscriber', () => {
     });
   });
 
+  describe('with className prop', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(<OTSubscriber className="myclass" />);
+    });
+
+    it('should render class on wrapper element', () => {
+      const divWrapper = wrapper.render().find('div.myclass');
+      expect(divWrapper.length).toBe(1);
+    });
+  });
+
+  describe('with style prop', () => {
+    let wrapper;
+    const style = { color: 'red' };
+
+    beforeEach(() => {
+      wrapper = mount(<OTSubscriber style={style} />);
+    });
+
+    it('should render style attribute on wrapper element', () => {
+      expect(wrapper.containsMatchingElement(<div style={style} />)).toEqual(true);
+    });
+  });
+
   describe('with only stream prop', () => {
     let wrapper;
     let stream;


### PR DESCRIPTION
As discussed in #57 here is an attempt to address the issue of not being able to style the anonymous `div`.

I deliberately did not include a reference to issue 57 in the commit message, as #57 really is about documentation, not this improvement.