### PR TITLE
- add handleRetrySubscriber function in OTSubscriber Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ There are plans to support more Publisher properties but for now you will have t
 | stream | [Stream](https://tokbox.com/developer/sdks/js/reference/Stream.html) | No | OpenTok Stream instance. This is auto populated by wrapping `OTSubscriber` with `OTStreams`
 | properties | Object | No | Properties passed into `session.subscribe`
 | retry | Boolean | No | Set true to retry the subscribe process in case of failure (Default: false)
-| maxRetryAttempts | Number | No | Max retry attempts in case of subscribe failure (Default: 15)
+| maxRetryAttempts | Number | No | Max retry attempts in case of subscribe failure (Default: 5)
 | retryAttemptTimeout | Number | No | Timeout value between every subscribe retry attempt, expressed in ms (Default: 1000ms)
 | eventHandlers | Object&lt;Function&gt; | No | Event handlers passed into `subscriber.on`
 | onSubscribe | Function() | No | Invoked when `session.subscribe` successfully completes

--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ There are plans to support more Publisher properties but for now you will have t
 | session | [Session](https://tokbox.com/developer/sdks/js/reference/Session.html) | No | OpenTok Session instance. This is auto populated by wrapping `OTSubscriber` with `OTStreams`
 | stream | [Stream](https://tokbox.com/developer/sdks/js/reference/Stream.html) | No | OpenTok Stream instance. This is auto populated by wrapping `OTSubscriber` with `OTStreams`
 | properties | Object | No | Properties passed into `session.subscribe`
+| retry | Boolean | No | Set true to retry the subscribe process in case of failure (Default: false)
+| maxRetryAttempts | Number | No | Max retry attempts in case of subscribe failure (Default: 15)
+| retryAttemptTimeout | Number | No | Timeout value between every subscribe retry attempt, expressed in ms (Default: 1000ms)
 | eventHandlers | Object&lt;Function&gt; | No | Event handlers passed into `subscriber.on`
 | onSubscribe | Function() | No | Invoked when `session.subscribe` successfully completes
 | onError | Function(err) | No | Invoked when `session.subscribe` fails

--- a/example/components/Subscriber.js
+++ b/example/components/Subscriber.js
@@ -37,6 +37,8 @@ export default class Subscriber extends Component {
           }}
           onError={this.onError}
           retry={true}
+          maxRetryAttempts={3}
+          retryAttemptTimeout={2000}
         />
         <CheckBox
           label="Subscribe to Audio"

--- a/example/components/Subscriber.js
+++ b/example/components/Subscriber.js
@@ -36,6 +36,7 @@ export default class Subscriber extends Component {
             subscribeToVideo: this.state.video
           }}
           onError={this.onError}
+          retry={true}
         />
         <CheckBox
           label="Subscribe to Audio"

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -10,7 +10,10 @@ export default class OTSubscriber extends Component {
       subscriber: null,
       stream: props.stream || context.stream || null,
       session: props.session || context.session || null,
+      currentRetryAttempt: 0,
     };
+    this.maxRetryAttempts = props.maxRetryAttempts || 15;
+    this.retryAttemptTimeout = props.retryAttemptTimeout || 1000;
   }
 
   componentDidMount() {
@@ -57,33 +60,47 @@ export default class OTSubscriber extends Component {
 
     this.subscriberId = uuid();
     const { subscriberId } = this;
-
     const subscriber = this.state.session.subscribe(
-      this.state.stream,
-      container,
-      this.props.properties,
-      (err) => {
-        if (subscriberId !== this.subscriberId) {
-          // Either this subscriber has been recreated or the
-          // component unmounted so don't invoke any callbacks
-          return;
-        }
-        if (err && typeof this.props.onError === 'function') {
-          this.props.onError(err);
-        } else if (!err && typeof this.props.onSubscribe === 'function') {
-          this.props.onSubscribe();
-        }
-      },
-    );
+            this.state.stream,
+            container,
+            this.props.properties,
+            (err) => {
+              if (subscriberId !== this.subscriberId) {
+                    // Either this subscriber has been recreated or the
+                    // component unmounted so don't invoke any callbacks
+                return;
+              }
+              if (err && this.props.retry && this.state.currentRetryAttempt < this.maxRetryAttempts) {
+                    // Error during subscribe function
+                this.handleRetrySubscriber();
+                // If there is a retry action, do we want to execute the onError props function?
+                // return;
+              }
+              if (err && typeof this.props.onError === 'function') {
+                this.props.onError(err);
+              } else if (!err && typeof this.props.onSubscribe === 'function') {
+                this.props.onSubscribe();
+              }
+            },
+        );
 
     if (
-      this.props.eventHandlers &&
-      typeof this.props.eventHandlers === 'object'
-    ) {
+            this.props.eventHandlers &&
+            typeof this.props.eventHandlers === 'object'
+        ) {
       subscriber.on(this.props.eventHandlers);
     }
 
     this.setState({ subscriber });
+  }
+
+  handleRetrySubscriber() {
+    setTimeout(() => {
+      let { currentRetryAttempt } = this.state;
+      currentRetryAttempt += 1;
+      this.setState({ subscriber: null, currentRetryAttempt });
+      this.createSubscriber();
+    }, this.retryAttemptTimeout);
   }
 
   destroySubscriber(session = this.props.session) {
@@ -91,9 +108,9 @@ export default class OTSubscriber extends Component {
 
     if (this.state.subscriber) {
       if (
-        this.props.eventHandlers &&
-        typeof this.props.eventHandlers === 'object'
-      ) {
+                this.props.eventHandlers &&
+                typeof this.props.eventHandlers === 'object'
+            ) {
         this.state.subscriber.once('destroyed', () => {
           this.state.subscriber.off(this.props.eventHandlers);
         });
@@ -119,6 +136,9 @@ OTSubscriber.propTypes = {
     unsubscribe: PropTypes.func,
   }),
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  retry: PropTypes.bool,
+  maxRetryAttempts: PropTypes.number,
+  retryAttemptTimeout: PropTypes.number,
   eventHandlers: PropTypes.objectOf(PropTypes.func),
   onSubscribe: PropTypes.func,
   onError: PropTypes.func,
@@ -128,6 +148,9 @@ OTSubscriber.defaultProps = {
   stream: null,
   session: null,
   properties: {},
+  retry: false,
+  maxRetryAttempts: 15,
+  retryAttemptTimeout: 1000,
   eventHandlers: null,
   onSubscribe: null,
   onError: null,

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -12,7 +12,7 @@ export default class OTSubscriber extends Component {
       session: props.session || context.session || null,
       currentRetryAttempt: 0,
     };
-    this.maxRetryAttempts = props.maxRetryAttempts || 15;
+    this.maxRetryAttempts = props.maxRetryAttempts || 5;
     this.retryAttemptTimeout = props.retryAttemptTimeout || 1000;
   }
 
@@ -60,6 +60,7 @@ export default class OTSubscriber extends Component {
 
     this.subscriberId = uuid();
     const { subscriberId } = this;
+
     const subscriber = this.state.session.subscribe(
             this.state.stream,
             container,
@@ -72,8 +73,8 @@ export default class OTSubscriber extends Component {
               }
               if (err &&
                 this.props.retry &&
-                this.state.currentRetryAttempt < this.maxRetryAttempts) {
-                    // Error during subscribe function
+                this.state.currentRetryAttempt < (this.maxRetryAttempts - 1)) {
+                // Error during subscribe function
                 this.handleRetrySubscriber();
                 // If there is a retry action, do we want to execute the onError props function?
                 // return;
@@ -98,9 +99,10 @@ export default class OTSubscriber extends Component {
 
   handleRetrySubscriber() {
     setTimeout(() => {
-      let { currentRetryAttempt } = this.state;
-      currentRetryAttempt += 1;
-      this.setState({ subscriber: null, currentRetryAttempt });
+      this.setState(state => ({
+        currentRetryAttempt: state.currentRetryAttempt + 1,
+        subscriber: null,
+      }));
       this.createSubscriber();
     }, this.retryAttemptTimeout);
   }
@@ -151,7 +153,7 @@ OTSubscriber.defaultProps = {
   session: null,
   properties: {},
   retry: false,
-  maxRetryAttempts: 15,
+  maxRetryAttempts: 5,
   retryAttemptTimeout: 1000,
   eventHandlers: null,
   onSubscribe: null,

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -70,7 +70,9 @@ export default class OTSubscriber extends Component {
                     // component unmounted so don't invoke any callbacks
                 return;
               }
-              if (err && this.props.retry && this.state.currentRetryAttempt < this.maxRetryAttempts) {
+              if (err &&
+                this.props.retry &&
+                this.state.currentRetryAttempt < this.maxRetryAttempts) {
                     // Error during subscribe function
                 this.handleRetrySubscriber();
                 // If there is a retry action, do we want to execute the onError props function?


### PR DESCRIPTION
I added retry logic in Subscriber component. In the case of subscriber failure, the function retries the process at most `maxRetryAttempts` times.

I have a doubt in line [76](https://github.com/opentok/opentok-react/compare/master...nexmo-saleseng:feature.retry_subscriber_logic?expand=1#diff-96d32aee104a96ccd6a8fdf3ebfe6517R76) if, in case of failure, the function has either to call or skip the `onError` function defined in the props of the component.
