### PR TITLE
Republish/Resubscribe action buttons added in example app

### DIFF
--- a/example/components/App.js
+++ b/example/components/App.js
@@ -23,6 +23,48 @@ class App extends Component {
         this.setState({ connected: false });
       }
     };
+
+    this.publisherEventHandlers = {
+        accessDenied: () => {
+          console.log('User denied access to media source')
+        },
+        accessAllowed: () => {
+          console.log('User allowed access to media source')
+        },
+        streamCreated: () => {
+          console.log('Publisher stream created')
+        },
+        streamDestroyed: ({ reason }) => {
+          console.log(`Publisher stream destroyed, reason: ${reason}`)
+        },
+        disconnected: () => {
+          console.log('Publisher disconnected')
+        },
+        destroyed: () => {
+          console.log('Publisher destroyed')
+        }
+      }
+
+    this.subscriberEventHandlers = {
+          videoEnabled: () => {
+            console.log('Subscriber video enabled')
+          },
+          videoDisabled: () => {
+            console.log('Subscriber video disabled')
+          },
+          streamDestroyed: ({ reason }) => {
+            console.log(`Subscriber stream destroyed, reason: ${reason}`)
+          },
+          connected: () => {
+            console.log('Subscriber connected')
+          },
+          disconnected: () => {
+            console.log('Subscriber disconnected')
+          },
+          destroyed: () => {
+            console.log('Subscriber destroyed')
+          }
+      }
   }
 
   componentWillMount() {
@@ -44,9 +86,9 @@ class App extends Component {
       >
         {this.state.error ? <div>{this.state.error}</div> : null}
         <ConnectionStatus connected={this.state.connected} />
-        <Publisher />
+        <Publisher eventHandlers={this.publisherEventHandlers}/>
         <OTStreams>
-          <Subscriber />
+          <Subscriber eventHandlers={this.subscriberEventHandlers}/>
         </OTStreams>
       </OTSession>
     );

--- a/example/components/Publisher.js
+++ b/example/components/Publisher.js
@@ -5,70 +5,79 @@ import RadioButtons from './RadioButtons';
 import CheckBox from './CheckBox';
 
 export default class Publisher extends Component {
-  constructor(props) {
-    super(props);
+    constructor( props ) {
+        super( props );
 
-    this.state = {
-      error: null,
-      audio: true,
-      video: true,
-      videoSource: 'camera'
-    };
-  }
+        this.state = {
+            error: null,
+            audio: true,
+            video: true,
+            videoSource: 'camera'
+        };
+        this.otPublisher = null;
+    }
 
-  setAudio = (audio) => {
-    this.setState({ audio });
-  }
+    setAudio = ( audio ) => {
+        this.setState( { audio } );
+    }
 
-  setVideo = (video) => {
-    this.setState({ video });
-  }
+    setVideo = ( video ) => {
+        this.setState( { video } );
+    }
 
-  setVideoSource = (videoSource) => {
-    this.setState({ videoSource });
-  }
+    setVideoSource = ( videoSource ) => {
+        this.setState( { videoSource } );
+    }
 
-  onError = (err) => {
-    this.setState({ error: `Failed to publish: ${err.message}` });
-  }
+    onError = ( err ) => {
+        this.setState( { error: `Failed to publish: ${err.message}` } );
+    }
 
-  render() {
-    return (
-      <div>
-        {this.state.error ? <div>{this.state.error}</div> : null}
-        <OTPublisher
-          properties={{
-            publishAudio: this.state.audio,
-            publishVideo: this.state.video,
-            videoSource: this.state.videoSource === 'screen' ? 'screen' : undefined
-          }}
-          onError={this.onError}
-        />
-        <RadioButtons
-          buttons={[
-            {
-              label: 'Camera',
-              value: 'camera'
-            },
-            {
-              label: 'Screen',
-              value: 'screen'
-            }
-          ]}
-          initialChecked={this.state.videoSource}
-          onChange={this.setVideoSource}
-        />
-        <CheckBox
-          label="Publish Audio"
-          initialChecked={this.state.audio}
-          onChange={this.setAudio}
-        />
-        <CheckBox
-          label="Publish Video"
-          initialChecked={this.state.video}
-          onChange={this.setVideo}
-        />
-      </div>
-    );
-  }
+    rePublish = () => {
+        this.otPublisher.destroyPublisher();
+        this.otPublisher.createPublisher();
+    }
+
+    render () {
+        return (
+            <div>
+                {this.state.error ? <div>{this.state.error}</div> : null}
+                <OTPublisher
+                    properties={{
+                        publishAudio: this.state.audio,
+                        publishVideo: this.state.video,
+                        videoSource: this.state.videoSource === 'screen' ? 'screen' : undefined
+                    }}
+                    onError={this.onError}
+                    eventHandlers={this.props.eventHandlers}
+                    ref={(instance) => { this.otPublisher = instance }}
+                />
+                <RadioButtons
+                    buttons={[
+                        {
+                            label: 'Camera',
+                            value: 'camera'
+                        },
+                        {
+                            label: 'Screen',
+                            value: 'screen'
+                        }
+                    ]}
+                    initialChecked={this.state.videoSource}
+                    onChange={this.setVideoSource}
+                />
+                <CheckBox
+                    label="Publish Audio"
+                    initialChecked={this.state.audio}
+                    onChange={this.setAudio}
+                />
+                <CheckBox
+                    label="Publish Video"
+                    initialChecked={this.state.video}
+                    onChange={this.setVideo}
+                />
+                <button onClick={this.rePublish} > Republish </button>
+            </div>
+        );
+    }
 }

--- a/example/components/Subscriber.js
+++ b/example/components/Subscriber.js
@@ -12,6 +12,8 @@ export default class Subscriber extends Component {
       audio: true,
       video: true
     };
+
+    this.otSubscriber = null;
   }
 
   setAudio = (audio) => {
@@ -26,6 +28,11 @@ export default class Subscriber extends Component {
     this.setState({ error: `Failed to subscribe: ${err.message}` });
   }
 
+  reSubscribe = () => {
+        this.otSubscriber.destroySubscriber(this.otSubscriber.state.session);
+        this.otSubscriber.createSubscriber();
+    }
+
   render() {
     return (
       <div>
@@ -36,6 +43,8 @@ export default class Subscriber extends Component {
             subscribeToVideo: this.state.video
           }}
           onError={this.onError}
+          eventHandlers={this.props.eventHandlers}
+          ref={(instance) => { this.otSubscriber = instance }}
         />
         <CheckBox
           label="Subscribe to Audio"
@@ -47,6 +56,7 @@ export default class Subscriber extends Component {
           initialChecked={this.state.video}
           onChange={this.setVideo}
         />
+        <button onClick={this.reSubscribe} > Resubscribe </button>
       </div>
     );
   }


### PR DESCRIPTION
Hi,

I added in the example App two buttons, one for the republish action and one for the resubscribe action.
The goal is to provide an example on how to destroy and republish a stream (same for the subscriber logic) using React Ref (https://reactjs.org/docs/refs-and-the-dom.html).

I also added console.log for all the events fired by OTSession, OTPublisher and OTSubscriber.
