### PR TITLE
Optimise lodash imports for smaller webpack bundles

### DIFF
--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import once from 'lodash/once';
-import { omitBy, isNil } from 'lodash/fp';
+import omitBy from 'lodash/fp/omitBy';
+import isNil from 'lodash/fp/isNil';
 import uuid from 'uuid';
 
 export default class OTPublisher extends Component {


### PR DESCRIPTION
Importing multiple modules from `lodash/fp` results in neat code, but it has an unfortunate side effect in webpack and browserify builds. Importing from the top-level package brings in the entire `lodash` library, instead of just the two methods used.

This PR splits the import into 2 separate imports, in the same way as the `lodash/once` import above them.

To test the result, I created a super-simple webpack project, where the only code is this:

```js
import { OTPublisher } from 'opentok-react';
```

Running `webpack` on this file in production mode, with `opentok-react` version `0.9.0`, results in the following file sizes:

File | Size
---|---
index.js | 113K
index.js.gz | 36K

Running the same build using this PR:

File | Size
---|---
index.js | 88K
index.js.gz | 26K