### PR TITLE
Change travis distribution to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 sudo: required
-dist: trusty
+services:
+  - xvfb
 language: node_js
 node_js:
   - 6
-
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 script: ./node_modules/.bin/run-tests
 


### PR DESCRIPTION
**What is this PR doing?**
This PR fixes a bug in travis builds. Google has dropped Trusty support in Chrome .deb packages so we need to migrate to xenial distribution (which is the default in travis).