### PR TITLE
Bump uuid version to 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15.5.10",
     "react-display-name": "^0.2.0",
     "scriptjs": "^2.5.8",
-    "uuid": "^3.0.1"
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.34",

--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import once from 'lodash/once';
 import { omitBy, isNil } from 'lodash/fp';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default class OTPublisher extends Component {
   constructor(props, context) {

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default class OTSubscriber extends Component {
   constructor(props, context) {

--- a/test/OTPublisher.spec.js
+++ b/test/OTPublisher.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 import OTPublisher from '../src/OTPublisher';
 
 describe('OTPublisher', () => {
@@ -135,6 +136,12 @@ describe('OTPublisher', () => {
           'sessionConnected',
           jasmine.any(Function),
         );
+      });
+
+      it('should have a valid publisherId', () => {
+        const { publisherId } = wrapper.instance();
+        expect(uuidValidate(publisherId)).toBe(true);
+        expect(uuidVersion(publisherId)).toEqual(4);
       });
     });
 

--- a/test/OTSubscriber.spec.js
+++ b/test/OTSubscriber.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 import OTSubscriber from '../src/OTSubscriber';
 
 describe('OTSubscriber', () => {
@@ -127,6 +128,12 @@ describe('OTSubscriber', () => {
     it('should have a subscriber', () => {
       expect(wrapper.instance().getSubscriber()).toBe(subscriber);
       expect(wrapper.state('subscriber')).toBe(subscriber);
+    });
+
+    it('should have a valid subscriberId', () => {
+      const { subscriberId } = wrapper.instance();
+      expect(uuidValidate(subscriberId)).toBe(true);
+      expect(uuidVersion(subscriberId)).toEqual(4);
     });
 
     it('should unsubscribe when unmounting', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5647,9 +5647,14 @@ uuid@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1:
+uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
+uuid@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8flags@^2.0.10:
   version "2.1.1"


### PR DESCRIPTION
According to change log UUID v8.3.0 should have better **UUIDv4** performance and introduces ECMAScript modules that should reduce build sizes. 

Complete change log can be found here: https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md

I have upgraded dependency according to upgrade [guide](https://github.com/uuidjs/uuid#upgrading-from-uuid3x). Previous versions generated **UUIDv4** by [default](https://github.com/uuidjs/uuid#default-export-removed) for this reason I have contributed with a few tests to ensure that **UUIDv4** are still generated for publisher and subscriber IDs.