### PR TITLE
add `onError` hook to `createSession` parameters

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,6 +54,7 @@ export interface CreateSessionOptions {
   sessionId: string;
   token: string;
   onStreamsUpdated?: (streams: Stream[]) => void;
+  onError?: (error: Error) => void;
 }
 
 export interface SessionHelper {


### PR DESCRIPTION
Present in JS here:

https://github.com/opentok/opentok-react/blob/8cab1f6c2d1c5b04b37dcebfa2e84d4dfffe3c34/src/createSession.js#L7

needed to handle connection issues when trying to join a session